### PR TITLE
Add logic to auto-generate coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+
+ignore_errors = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
 [report]
 
 ignore_errors = True
+
+omit =
+    config.py
+    config-3.py

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,41 @@
+# @format
+
+name: Coverage Report
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install coverage
+      - name: Get coverage report
+        run: |
+          coverage run -m pytest -s
+          coverage report > coverage.txt
+          cat coverage.txt
+      - name: Commit and push coverage.txt
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git add coverage.txt
+          git commit -m "Update coverage report" || echo "No changes to commit"
+          git push
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -34,7 +34,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git add coverage.txt
           git commit -m "Update coverage report" || echo "No changes to commit"
-          git push
+          git push || echo "Not on a branch, skipping push"
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/coverage.txt
+++ b/coverage.txt
@@ -1,0 +1,14 @@
+Name                                 Stmts   Miss  Cover
+--------------------------------------------------------
+api/index.py                           101     49    51%
+api/tests/__init__.py                    0      0   100%
+api/tests/conftest.py                    7      0   100%
+api/tests/test_index.py                 20      0   100%
+api/tests/test_utils.py                 27      0   100%
+api/utils/__init__.py                    0      0   100%
+api/utils/braille_image_to_text.py      95     85    11%
+api/utils/braille_to_text.py            29      1    97%
+api/utils/image_to_braille.py           28     22    21%
+api/utils/text_to_braille.py            38      6    84%
+--------------------------------------------------------
+TOTAL                                  345    163    53%


### PR DESCRIPTION
Add logic to `auto-generate` coverage report using `github-actions`.

according to [this](https://stackoverflow.com/questions/72660954/coverage-no-source-for-code-with-pytest) issue, we need to add `config.py` and `config-3.py` to omit which gets generated randomly.